### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "author": "Sebastian <sebastian@comci.de>",
     "license": "MIT",
     "peerDependencies": {
-        "commonmark": ">= 0.29.2 <= 0.31.0",
-        "pdfkit": " >= 0.8.3 <= 0.15.0"
+        "commonmark": ">= 0.29.2",
+        "pdfkit": " >= 0.8.3"
     },
     "devDependencies": {
         "@babel/cli": "^7.18.6",


### PR DESCRIPTION
Allow newer versions of pdfkit and commonmark. The recent ones still work. Thanks for the repo!

(For unmaintained projects an upper version bound is not needed.)